### PR TITLE
fix: updated 2022 public holidays

### DIFF
--- a/api/2022/data.json
+++ b/api/2022/data.json
@@ -3,10 +3,10 @@
 {"Date":"2022-02-01","Name":"Chinese New Year Day 1","Day":"Tuesday","Observance":"2022-02-01","Observance Strategy":"actual_day"},
 {"Date":"2022-02-02","Name":"Chinese New Year Day 2","Day":"Wednesday","Observance":"2022-02-02","Observance Strategy":"actual_day"},
 {"Date":"2022-04-15","Name":"Good Friday","Day":"Friday","Observance":"2022-04-15","Observance Strategy":"actual_day"},
-{"Date":"2022-05-01","Name":"Labour Day","Day":"Sunday","Observance":"2022-05-01","Observance Strategy":"next_tuesday"},
-{"Date":"2022-05-02","Name":"Hari Raya Puasa","Day":"Monday","Observance":"2022-05-02","Observance Strategy":"actual_day"},
+{"Date":"2022-05-01","Name":"Labour Day","Day":"Sunday","Observance":"2022-05-01","Observance Strategy":"next_monday"},
+{"Date":"2022-05-03","Name":"Hari Raya Puasa","Day":"Tuesday","Observance":"2022-05-03","Observance Strategy":"actual_day"},
 {"Date":"2022-05-15","Name":"Vesak Day","Day":"Sunday","Observance":"2022-05-16","Observance Strategy":"next_monday"},
-{"Date":"2022-07-09","Name":"Hari Raya Haji","Day":"Saturday","Observance":"2022-07-09","Observance Strategy":"actual_day"},
+{"Date":"2022-07-10","Name":"Hari Raya Haji","Day":"Sunday","Observance":"2022-07-10","Observance Strategy":"next_monday"},
 {"Date":"2022-08-09","Name":"National Day","Day":"Tuesday","Observance":"2022-08-09","Observance Strategy":"actual_day"},
 {"Date":"2022-10-24","Name":"Deepavali","Day":"Monday","Observance":"2022-10-24","Observance Strategy":"actual_day"},
 {"Date":"2022-12-25","Name":"Christmas Day","Day":"Sunday","Observance":"2022-12-26","Observance Strategy":"next_monday"}

--- a/csv/2022_singapore_holidays.csv
+++ b/csv/2022_singapore_holidays.csv
@@ -3,10 +3,10 @@ Date,Name,Day,Observance,Observance Strategy
 2022-02-01,Chinese New Year Day 1,Tuesday,2022-02-01,actual_day
 2022-02-02,Chinese New Year Day 2,Wednesday,2022-02-02,actual_day
 2022-04-15,Good Friday,Friday,2022-04-15,actual_day
-2022-05-01,Labour Day,Sunday,2022-05-01,next_tuesday
-2022-05-02,Hari Raya Puasa,Monday,2022-05-02,actual_day
+2022-05-01,Labour Day,Sunday,2022-05-01,next_monday
+2022-05-03,Hari Raya Puasa,Tuesday,2022-05-03,actual_day
 2022-05-15,Vesak Day,Sunday,2022-05-16,next_monday
-2022-07-09,Hari Raya Haji,Saturday,2022-07-09,actual_day
+2022-07-10,Hari Raya Haji,Sunday,2022-07-10,next_monday
 2022-08-09,National Day,Tuesday,2022-08-09,actual_day
 2022-10-24,Deepavali,Monday,2022-10-24,actual_day
 2022-12-25,Christmas Day,Sunday,2022-12-26,next_monday


### PR DESCRIPTION
- fixed mistake for labour day observance
- updated hari raya dates according to https://www.channelnewsasia.com/singapore/public-holidays-new-dates-hari-raya-puasa-hari-raya-haji-2022-2258426